### PR TITLE
Improved logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,5 +82,7 @@ the DOAJ, then request the articles for each of those ISSNs from EPMC, and fire 
 ## Rotating the logs
 
 The harvester creates a fair amount of log output, so it's best to rotate and archive old logs using ```logrotate```.
-Copy the config from ```deploy/logrotate/doaj-harvester``` into the logrotate directory at ```/etc/logorotate.d/``` and
-it will be picked up on the next daily run of logrotate.
+Symlink the config from ```deploy/logrotate/doaj-harvester``` into the logrotate directory at ```/etc/logorotate.d/``` and
+it will be picked up on the next cron.daily run of logrotate. E.g:
+
+    ﻿sudo ln -s /full/path/to/deploy/logrotate/doaj-harvester /etc/logrotate.d/doaj-harvester

--- a/README.md
+++ b/README.md
@@ -78,3 +78,9 @@ Then you just need to start the harvester with:
 This will run through each account id in the API_KEYS list, and for each one retrieve the ISSNs from
 the DOAJ, then request the articles for each of those ISSNs from EPMC, and fire it over to the DOAJ
 (authenticating with that account's API key).
+
+## Rotating the logs
+
+The harvester creates a fair amount of log output, so it's best to rotate and archive old logs using ```logrotate```.
+Copy the config from ```deploy/logrotate/doaj-harvester``` into the logrotate directory at ```/etc/logorotate.d/``` and
+it will be picked up on the next daily run of logrotate.

--- a/deploy/logrotate/doaj-harvester
+++ b/deploy/logrotate/doaj-harvester
@@ -1,0 +1,14 @@
+/home/cloo/cron-logs/harvester.log {
+	weekly
+	missingok
+	rotate 52
+	compress
+	delaycompress
+	notifempty
+	dateext
+	dateyesterday
+}
+
+# rotate 52       Only keep a year's worth of logs
+# delaycompress   Compress the following time it's run, not immediately
+# dateyesterday   Logs will run up to and include the date in the filename

--- a/service/runner.py
+++ b/service/runner.py
@@ -1,8 +1,21 @@
 from service import workflow
 from octopus.core import app, initialise
+import flask.logging
 
 if __name__ == "__main__":
     initialise()
+
+    if app.debug:
+        # Augment the default flask debug log to include a timestamp
+        app.debug_log_format = (
+            '-' * 80 + '\n' +
+            '%(asctime)s\n'
+            '%(levelname)s in %(module)s [%(pathname)s:%(lineno)d]:\n' +
+            '%(message)s\n' +
+            '-' * 80
+        )
+        flask.logging.create_logger(app)
+
     accs = app.config.get("API_KEYS", {}).keys()
     for account_id in accs:
         workflow.HarvesterWorkflow.process_account(account_id)


### PR DESCRIPTION
* Added ```log rotate``` configuration
* Edited the app's default debug log (when ```DEBUG=True```) to include a timestamp. A fuller solution would add a logger for production. This may be considered for octopus.