### PR TITLE
Send emails

### DIFF
--- a/config/service.py
+++ b/config/service.py
@@ -71,5 +71,9 @@ EPMC_HARVESTER_THROTTLE = 0.2
 STARTING_PROCTITLE = 'harvester: starting'
 RUNNING_PROCTITLE = 'harvester: running'
 
-# minutes we wait between terminate and kill
+# Minutes we wait between terminate and kill
 MAX_WAIT = 10
+
+# Email notifications
+EMAIL_ON_EVENT = False
+EMAIL_RECIPIENTS = None

--- a/service/runner.py
+++ b/service/runner.py
@@ -12,7 +12,7 @@ MAX_WAIT = app.config.get('MAX_WAIT', 10)
 
 
 def run_only_once():
-    # identify running harvester instances
+    # Identify running harvester instances.
     setproctitle(STARTING_PROCTITLE)
     running_harvesters = []
     starting_harvesters = []
@@ -29,31 +29,45 @@ def run_only_once():
         print "Harvester is already starting. Aborting this instance."
         exit(1)
 
-    # send SIGTERM to all extant instances of the harvester
+    # Send SIGTERM to all extant instances of the harvester.
     if len(running_harvesters) > 0:
         [h.terminate() for h in running_harvesters]
 
-    # check if they terminated correctly
+    # Check if they terminated correctly
     started = datetime.datetime.utcnow()
     still_running = filter(lambda hrv: hrv.is_running(), running_harvesters)
     while len(still_running) > 0 and datetime.datetime.utcnow() - started < datetime.timedelta(minutes=MAX_WAIT):
         time.sleep(10)
         still_running = filter(lambda hrv: hrv.is_running(), running_harvesters)
 
-    # move on to killing the processes if they don't respond to terminate
+    # Move on to killing the processes if they don't respond to terminate
     if len(still_running) > 0:
         [h.kill() for h in running_harvesters]
         time.sleep(10)
 
-    # startup complete, change process name to running
+    # Startup complete, change process name to running.
     setproctitle(RUNNING_PROCTITLE)
 
 if __name__ == "__main__":
     run_only_once()
     initialise()
 
+    # Send an email when the harvester starts.
+    mail_prereqs = False
+    if app.config.get("EMAIL_ON_EVENT", False):
+        to = app.config.get("EMAIL_RECIPIENTS", None)
+
+        if to is not None:
+            mail_prereqs = True
+            from octopus.lib import mail
+            mail.send_mail(
+                to=to,
+                subject="DOAJ Harvester started at {0}".format(datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")),
+                msg_body="A new running instance of the harvester has started."
+            )
+
     if app.debug:
-        # Augment the default flask debug log to include a timestamp
+        # Augment the default flask debug log to include a timestamp.
         app.debug_log_format = (
             '-' * 80 + '\n' +
             '%(asctime)s\n'
@@ -67,4 +81,13 @@ if __name__ == "__main__":
     for account_id in accs:
         workflow.HarvesterWorkflow.process_account(account_id)
 
-    app.logger.info(Report.write_report())
+    report = Report.write_report()
+    app.logger.info(report)
+
+    # If the harvester finishes normally, we can email the report.
+    if mail_prereqs:
+        mail.send_mail(
+            to=app.config["EMAIL_RECIPIENTS"],
+            subject="DOAJ Harvester finished at {0}".format(datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")),
+            msg_body=report
+        )


### PR DESCRIPTION
#7 Enable emails when harvester starts and when it exits normally. The normal exit will contain the report.

I have decided not to email the report when the harvester catches SIGTERM, but it could be added; it will just slow down the exit some more.

The following new settings must be included in the ```app.cfg```:

```
# Email notifications
EMAIL_ON_EVENT = True
EMAIL_RECIPIENTS = ['steve@cottagelabs.com']

MAIL_FROM_ADDRESS = "harvester@doaj.org"
MAIL_SUBJECT_PREFIX = "[harvester] "

# Settings for Flask-Mail.
MAIL_SERVER = 
MAIL_PORT = 
MAIL_DEBUG = False
MAIL_USERNAME = 
MAIL_PASSWORD =
MAIL_DEFAULT_SENDER = 'harvester@doaj.org'
```

I've debugged this with mailtrap.io, and as far as I can tell, updating octopus had no ill effects - it was necessary to get a bugfix.