### PR TITLE
Feature/13 start from beginning

### DIFF
--- a/service/models/epmc.py
+++ b/service/models/epmc.py
@@ -56,10 +56,21 @@ class EPMCHarvester(HarvesterPlugin):
         bj.journal = {}
         journal = bj.journal
 
+        # sort out the issns - EPMC sometimes puts the same value in the issn and essn fields.  I guess this is
+        # because they regard the issn to be the essn if there is no print issn.  This little trick below extracts
+        # the values to pissn and eissn, and then if they are the same, gets rid of the pissn.
+        pissn = record.issn
+        eissn = record.essn
+        if pissn == eissn:
+            pissn = None
+
+        if pissn is not None:
+            article.add_identifier("pissn", pissn)
+        if eissn is not None:
+            article.add_identifier("eissn", eissn)
+
         bj.title = record.title
         article.add_identifier("doi", record.doi)
-        article.add_identifier("pissn", record.issn)
-        article.add_identifier("eissn", record.essn)
         journal.volume = record.journal_volume
         journal.number = record.journal_issue
         journal.title = record.journal

--- a/service/tests/fixtures/harvester.py
+++ b/service/tests/fixtures/harvester.py
@@ -8,7 +8,7 @@ class HarvestStateFactory(object):
 
 STATE = {
     "id" : "oqwiwfqwjfwejfw",
-    "create_date": "1970-01-01T00:00:00Z",
+    "created_date": "1970-01-01T00:00:00Z",
     "last_updated" : "1970-01-01T00:00:00Z",
     "issn" : "1234-5678",
     "account" : "123456789",

--- a/service/tests/unit/test_state.py
+++ b/service/tests/unit/test_state.py
@@ -1,5 +1,5 @@
 """
-Unit tests for the DOAJ client
+Unit tests for the Harvest State mechanics
 """
 
 from octopus.modules.es.testindex import ESTestCase

--- a/service/workflow.py
+++ b/service/workflow.py
@@ -20,7 +20,7 @@ class HarvesterWorkflow(object):
             issns += journal.all_issns()
         issns = list(set(issns))
 
-        app.logger.info(u"Account:{x} has {y} issns to harvest for".format(x=account_id, y=len(issns)))
+        app.logger.info(u"Account:{x} has {y} issns to harvest for: {z}".format(x=account_id, y=len(issns), z=",".join(issns)))
 
         # now update the issn states
         HarvesterWorkflow.process_issn_states(account_id, issns)


### PR DESCRIPTION
This fixes the issue where the harvester does not start from the beginning when it is next run #13 .

The issue was that an older version of esprit was included which did not play well with the DataObj code, resulting in a failure to correctly construct objects which are retrieved from ES.

This PR updates the esprit dependency.  It also introduces a number of minor tweaks for general improvement to the EPMC harvesting, including:

* A fix for a broken test fixture
* An improvement to the EPMC crosswalk to ensure that we can ingest some types of article which we couldn't before (ones where the ISSN is repeated by EPMC in both ISSN fields).
* Some minor logging enhancements for future debugging

In addition to merging and deploying this, we also need to clean up a bit of a mess left behind in the index due to this bug.  There are currently 1775 state records when there should be 13!  I recommend the following procedure:

1. Remove the "state" type, to clear all previous records
2. Update the local.cfg to set "2013-03-24T00:00:00Z" as the default start date - this is the oldest date from the existing state records, so the DOAJ should be up to date for all dates prior to that.
3. re-run the harvester manually once through to re-create the state index records, and ensure that the entire system and the DOAJ are up-to-date and in-sync
4. Resume running the harvester on a daily job as before




