### PR TITLE
Hotfix/2036 articles no authors

### DIFF
--- a/config/service.py
+++ b/config/service.py
@@ -51,6 +51,12 @@ STORE_TMP_DIR = paths.rel2abs(__file__, "..", "service", "tests", "local_store",
 DOAJ_API_BASE_URL = "https://doaj.org/api/v1/"
 
 ##############################################
+# EPMC Client configuration overrides
+
+EPMC_TARGET_VERSION = "6.1"
+
+
+##############################################
 # Application-specific configuration
 
 HARVESTERS = [

--- a/service/models/epmc.py
+++ b/service/models/epmc.py
@@ -95,7 +95,11 @@ class EPMCHarvester(HarvesterPlugin):
                     continue
 
             n = ""
+            if cn is not None:
+                n += cn
             if fn is not None:
+                if n != "":
+                    n += " "
                 n += fn
             if ln is not None:
                 if n != "":

--- a/service/models/epmc.py
+++ b/service/models/epmc.py
@@ -83,10 +83,17 @@ class EPMCHarvester(HarvesterPlugin):
         bj.abstract = record.abstract
 
         for a in record.authors:
+            cn = a.get("collectiveName")
             fn = a.get("firstName")
             ln = a.get("lastName")
-            if fn is None and ln is None:
-                continue
+
+            if fn is None and ln is None and cn is None:
+                # FIXME: hacking this for the moment, but the correct solution is to update the EPMC client library
+                # which we will do when we port the code over to the main DOAJ codebase
+                fn = record._get_single("authorString")
+                if fn is None:
+                    continue
+
             n = ""
             if fn is not None:
                 n += fn

--- a/service/models/harvester.py
+++ b/service/models/harvester.py
@@ -122,6 +122,7 @@ class HarvesterProgressReport(object):
     articles_processed = {}
     articles_saved_successfully = {}
     harvester_started = dates.now()
+    error_messages = []
 
     @classmethod
     def set_start_by_issn(cls, plugin, issn, date):
@@ -149,6 +150,10 @@ class HarvesterProgressReport(object):
             cls.articles_saved_successfully[plugin] = 1
 
     @classmethod
+    def record_error(cls, msg):
+        cls.error_messages.append(msg)
+
+    @classmethod
     def write_report(cls):
         report = [u"Harvester ran from {d1} to {d2}.".format(d1=cls.harvester_started, d2=dates.now())]
         for p_name in cls.last_harvest_dates_at_start_of_harvester.keys():
@@ -166,4 +171,6 @@ class HarvesterProgressReport(object):
                     d1=cls.last_harvest_dates_at_start_of_harvester[p_name][issn],
                     d2=cls.current_states[issn].get_last_harvest(p_name)
                 ))
+        report.append(u"Error messages/import failures:")
+        report += cls.error_messages
         return "\n".join(report)

--- a/service/tests/scratch.py
+++ b/service/tests/scratch.py
@@ -6,7 +6,17 @@ a.bibjson = {"title" : "whatever"}
 print a.bibjson.title
 """
 
-
+"""
+Harvest the article records from EPMC
 from service.models import EPMCHarvester
 h = EPMCHarvester()
 r = [x for x in h.iterate("2047-2978", "2015-01-01T00:00:00Z")]
+"""
+
+from octopus.core import app, initialise
+initialise()
+
+from service.workflow import HarvesterWorkflow
+from service.models import HarvesterProgressReport
+HarvesterWorkflow.process_issn("15449173", "1932-6203")
+print(HarvesterProgressReport.write_report())

--- a/service/tests/scratch.py
+++ b/service/tests/scratch.py
@@ -18,5 +18,7 @@ initialise()
 
 from service.workflow import HarvesterWorkflow
 from service.models import HarvesterProgressReport
-HarvesterWorkflow.process_issn("15449173", "1932-6203")
-print(HarvesterProgressReport.write_report())
+try:
+    HarvesterWorkflow.process_issn("15449173", "1932-6203")
+finally:
+    print(HarvesterProgressReport.write_report())

--- a/service/workflow.py
+++ b/service/workflow.py
@@ -100,6 +100,12 @@ class HarvesterWorkflow(object):
 
         if not article.is_api_valid():
             app.logger.info(u"Article for Account:{y} was not API valid ... skipping".format(y=account_id))
+
+            try:
+                doajclient.models.ArticleValidator(article.data)
+            except Exception as e:
+                Report.record_error(article.get_identifier("doi") + u" - " + e.message)
+
             return False
 
         # FIXME: in production, we will need a way to get the account_id's api_key
@@ -114,6 +120,7 @@ class HarvesterWorkflow(object):
             id, loc = doaj.create_article(article)
         except doajclient.DOAJException as e:
             app.logger.info(u"Article caused DOAJException: {m} ... skipping".format(m=e.message))
+            Report.record_error(article.get_identifier("doi") + u" - " + e.message)
             return False
         app.logger.info(u"Created article in DOAJ for Account:{x} with ID: {y}".format(x=account_id, y=id))
         return True


### PR DESCRIPTION
This PR does the following:

* Introduces some additional error logging in the run report email
* Relaxes the author constraint on the DOAJ API
* Improves the crosswalk to handle "collective" authors and a fall-back to "authorString" where no other author can be found